### PR TITLE
Add recognition JSON output and UI viewer

### DIFF
--- a/deployment/lambdas/code/correlation_specialist/lambda_handler.py
+++ b/deployment/lambdas/code/correlation_specialist/lambda_handler.py
@@ -9,6 +9,7 @@ import logging
 import os
 from datetime import datetime
 from typing import Any
+from xml.etree import ElementTree
 
 import boto3
 
@@ -19,6 +20,42 @@ from foundation import job_state
 logger = logging.getLogger()
 log_level = os.environ.get("LOGGING_LEVEL", "INFO").upper()
 logger.setLevel(getattr(logging, log_level, logging.INFO))
+
+
+def _xml_element_to_json(element: ElementTree.Element) -> dict[str, Any]:
+    """Convert XML to an order-preserving JSON representation."""
+    node: dict[str, Any] = {"tag": element.tag}
+    if element.attrib:
+        node["attributes"] = dict(element.attrib)
+    text = (element.text or "").strip()
+    if text:
+        node["text"] = text
+    children = [_xml_element_to_json(child) for child in element]
+    if children:
+        node["children"] = children
+    return node
+
+
+def _build_recognition_json(
+    xml_content: str,
+    *,
+    session_id: str,
+    page_number: str,
+    source_image_path: str,
+    generated_at: str,
+    xml_uri: str,
+) -> dict[str, Any]:
+    """Build the portable JSON recognition artifact saved beside correlated XML."""
+    root = ElementTree.fromstring(xml_content)
+    return {
+        "schema_version": "1.0",
+        "session_id": session_id,
+        "page_number": page_number,
+        "source_image_path": source_image_path,
+        "generated_at": generated_at,
+        "source": {"format": "xml", "s3_uri": xml_uri},
+        "recognition": _xml_element_to_json(root),
+    }
 
 
 def lambda_handler(
@@ -201,8 +238,12 @@ def lambda_handler(
             job_state.mark_failed(job_id, subtask, "OUTPUT_BUCKET not configured")
             return _error_response("OUTPUT_BUCKET not configured")
 
-        timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        generated_at = datetime.utcnow()
+        timestamp = generated_at.strftime("%Y%m%d_%H%M%S")
         s3_key = f"{session_id}/correlated/correlation_specialist_page_{page_number}_{timestamp}.xml"
+        correlation_specialist_uri = f"s3://{output_bucket}/{s3_key}"
+        json_key = f"{session_id}/correlated/recognition_page_{page_number}_{timestamp}.json"
+        recognition_json_uri = f"s3://{output_bucket}/{json_key}"
 
         # Verify we have content before writing
         if not unified_document or len(unified_document.strip()) == 0:
@@ -217,6 +258,19 @@ def lambda_handler(
             )
 
         body_bytes = unified_document.encode("utf-8")
+        try:
+            recognition_json = _build_recognition_json(
+                unified_document,
+                session_id=session_id,
+                page_number=str(page_number),
+                source_image_path=source_image_path,
+                generated_at=generated_at.isoformat(timespec="seconds") + "Z",
+                xml_uri=correlation_specialist_uri,
+            )
+        except ElementTree.ParseError as error:
+            job_state.mark_failed(job_id, subtask, f"Invalid correlated XML: {error}")
+            return _error_response(f"Unable to create recognition JSON: {error}")
+
         logger.info(
             "Writing %d bytes to S3: %s/%s", len(body_bytes), output_bucket, s3_key
         )
@@ -228,11 +282,18 @@ def lambda_handler(
             ContentType="application/xml",
             Tagging=f"session_id={session_id}&type=correlation_specialist&page={page_number}",
         )
+        s3.put_object(
+            Bucket=output_bucket,
+            Key=json_key,
+            Body=json.dumps(recognition_json, ensure_ascii=False, indent=2).encode("utf-8"),
+            ContentType="application/json",
+            Tagging=f"session_id={session_id}&type=recognition_json&page={page_number}",
+        )
 
-        correlation_specialist_uri = f"s3://{output_bucket}/{s3_key}"
         logger.info(
             "Saved correlation_specialist output to %s", correlation_specialist_uri
         )
+        logger.info("Saved recognition JSON to %s", recognition_json_uri)
         job_state.mark_complete(job_id, subtask, correlation_specialist_uri)
 
         return {
@@ -240,6 +301,7 @@ def lambda_handler(
             "body": json.dumps(
                 {
                     "correlation_specialist_uri": correlation_specialist_uri,
+                    "recognition_json_uri": recognition_json_uri,
                     "summary": summary,
                     "success": True,
                     "session_id": session_id,

--- a/ui/UI_README.md
+++ b/ui/UI_README.md
@@ -90,6 +90,7 @@ Browser (React/Vite)
     │                │   ├── AgentCore WebSocket proxy (chat, SSE to browser)
     │                │   ├── PDF upload to S3 (mints doc_id)
     │                │   ├── Job records (/api/jobs)
+    │                │   ├── Recognition JSON output browser
     │                │   ├── S3 file operations (manifests, prompts, schemas)
     │                │   ├── CloudWatch Logs Insights queries
     │                │   └── Evaluation and pricing endpoints
@@ -119,6 +120,17 @@ log as `[job] job_id=… doc_id=…`, so a chat transcript can be traced to its 
 
 Job status is computed at read time rather than stored — see the endpoint comments in
 `server/routes/core.js` for why.
+
+## Recognition JSON
+
+The correlation specialist stores an order-preserving JSON recognition file beside
+each correlated XML result under `<session_id>/correlated/`. The 🧾 Recognition JSON
+tab lists sessions, loads every page-level JSON file, and supports copy and download.
+
+| Endpoint                              | Returns                                      |
+| ------------------------------------- | -------------------------------------------- |
+| `GET /api/recognition/sessions`       | Sessions containing recognition JSON files  |
+| `GET /api/recognition/sessions/:sid`  | All page-level recognition files and content |
 
 ## Tech Stack
 
@@ -154,6 +166,7 @@ ui/
 │       ├── PricingCalculator.jsx  # Cost estimator
 │       ├── Observability.jsx      # CloudWatch queries
 │       ├── ChatLog.jsx            # Session log viewer
+│       ├── RecognitionOutput.jsx   # Recognition JSON viewer and download
 │       ├── StackList.jsx          # CDK stack deploy/destroy
 │       ├── SpecialistSelector.jsx # Specialist browser
 │       ├── S3ConfigEditor.jsx     # S3 config file editor

--- a/ui/server/routes/core.js
+++ b/ui/server/routes/core.js
@@ -406,6 +406,78 @@ export function mountCoreRoutes(app, PROJECT_ROOT) {
         catch { res.json({ content: 'Session not found' }); }
     });
 
+    // ── Recognition JSON ──
+
+    app.get('/api/recognition/sessions', async (_req, res) => {
+        if (!OUTPUT_BUCKET) return res.json([]);
+        try {
+            const sessions = new Map();
+            let token;
+            do {
+                const response = await s3Client.send(new ListObjectsV2Command({
+                    Bucket: OUTPUT_BUCKET,
+                    ContinuationToken: token,
+                }));
+                for (const object of response.Contents || []) {
+                    const match = object.Key.match(/^([^/]+)\/correlated\/recognition_page_.+\.json$/);
+                    if (!match) continue;
+                    const sessionId = match[1];
+                    const current = sessions.get(sessionId) || {
+                        sessionId,
+                        recognitionFileCount: 0,
+                        lastModified: null,
+                    };
+                    current.recognitionFileCount += 1;
+                    if (!current.lastModified || object.LastModified > current.lastModified) {
+                        current.lastModified = object.LastModified;
+                    }
+                    sessions.set(sessionId, current);
+                }
+                token = response.NextContinuationToken;
+            } while (token);
+            res.json([...sessions.values()].sort((a, b) =>
+                new Date(b.lastModified || 0) - new Date(a.lastModified || 0)
+            ));
+        } catch (error) {
+            res.status(500).json({ error: 'Unable to list recognition sessions' });
+        }
+    });
+
+    app.get('/api/recognition/sessions/:sid', async (req, res) => {
+        if (!OUTPUT_BUCKET) return res.status(503).json({ error: 'S3_OUTPUT_BUCKET not configured' });
+        const sessionId = req.params.sid;
+        if (!/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
+            return res.status(400).json({ error: 'Invalid session ID' });
+        }
+        try {
+            const objects = [];
+            let token;
+            do {
+                const response = await s3Client.send(new ListObjectsV2Command({
+                    Bucket: OUTPUT_BUCKET,
+                    Prefix: `${sessionId}/correlated/recognition_page_`,
+                    ContinuationToken: token,
+                }));
+                objects.push(...(response.Contents || []).filter(object => object.Key.endsWith('.json')));
+                token = response.NextContinuationToken;
+            } while (token);
+
+            objects.sort((a, b) => a.Key.localeCompare(b.Key, undefined, { numeric: true }));
+            if (!objects.length) return res.status(404).json({ error: 'No recognition JSON found for this session' });
+
+            const files = await Promise.all(objects.map(async object => ({
+                filename: object.Key.split('/').at(-1),
+                s3Uri: `s3://${OUTPUT_BUCKET}/${object.Key}`,
+                sizeBytes: object.Size,
+                lastModified: object.LastModified,
+                content: await s3GetJson(OUTPUT_BUCKET, object.Key),
+            })));
+            res.json({ sessionId, files });
+        } catch (error) {
+            res.status(500).json({ error: 'Unable to load recognition JSON' });
+        }
+    });
+
     // ── Specialists ──
 
     app.get('/api/specialists', async (_req, res) => {

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -10,6 +10,7 @@ import Evaluator from './components/Evaluator.jsx'
 import PricingCalculator from './components/PricingCalculator.jsx'
 import Observability from './components/Observability.jsx'
 import ChatLog from './components/ChatLog.jsx'
+import RecognitionOutput from './components/RecognitionOutput.jsx'
 import StackList from './components/StackList.jsx'
 import SpecialistSelector from './components/SpecialistSelector.jsx'
 import S3ConfigEditor from './components/S3ConfigEditor.jsx'
@@ -30,6 +31,7 @@ const TABS = [
     { id: 'pricing', label: '💰 Pricing' },
     { id: 'observability', label: '📊 Observability' },
     { id: 'chatlog', label: '📝 Chat Log' },
+    { id: 'recognition', label: '🧾 Recognition JSON' },
     // Admin tabs
     { id: 'stacks', label: '📦 Stacks', adminOnly: true },
     { id: 'specialists', label: '🔬 Specialists', adminOnly: true },
@@ -251,6 +253,7 @@ export default function App() {
             {tab === 'pricing' && <PricingCalculator />}
             {tab === 'observability' && <Observability />}
             {tab === 'chatlog' && <ChatLog />}
+            {tab === 'recognition' && <RecognitionOutput />}
 
             {/* Admin tabs */}
             {role === 'admin' && tab === 'stacks' && <StackList runSSE={runSSE} runSSEGet={runSSEGet} running={running} />}

--- a/ui/src/components/Home.jsx
+++ b/ui/src/components/Home.jsx
@@ -18,6 +18,7 @@ export default function Home({ onNavigate, branding = {} }) {
     ['pricing', '💰 Pricing', 'Estimate Bedrock costs for document workloads'],
     ['observability', '📊 Observability', 'View agent execution traces from CloudWatch'],
     ['chatlog', '📝 Chat Log', 'Browse historical chat sessions'],
+    ['recognition', '🧾 Recognition JSON', 'View, copy, and download recognition output files'],
   ]
 
   return (

--- a/ui/src/components/RecognitionOutput.jsx
+++ b/ui/src/components/RecognitionOutput.jsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import JsonHighlighter from './JsonHighlighter.jsx'
+
+export default function RecognitionOutput() {
+  const [sessions, setSessions] = useState([])
+  const [selected, setSelected] = useState('')
+  const [result, setResult] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [copyStatus, setCopyStatus] = useState('')
+
+  const formatted = useMemo(() => result ? JSON.stringify(result, null, 2) : '', [result])
+
+  async function loadSession(sessionId) {
+    if (!sessionId) return
+    setSelected(sessionId)
+    setLoading(true)
+    setError('')
+    setCopyStatus('')
+    try {
+      const response = await fetch(`/api/recognition/sessions/${encodeURIComponent(sessionId)}`)
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Unable to load recognition output')
+      setResult(data)
+    } catch (loadError) {
+      setResult(null)
+      setError(loadError.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function refresh() {
+    setLoading(true)
+    setError('')
+    try {
+      const response = await fetch('/api/recognition/sessions')
+      const data = await response.json()
+      if (!response.ok) throw new Error(data.error || 'Unable to list recognition sessions')
+      setSessions(data)
+      const nextSession = selected || data[0]?.sessionId
+      if (nextSession) await loadSession(nextSession)
+      else {
+        setResult(null)
+        setLoading(false)
+      }
+    } catch (refreshError) {
+      setSessions([])
+      setResult(null)
+      setError(refreshError.message)
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { refresh() }, [])
+
+  async function copyJson() {
+    try {
+      await navigator.clipboard.writeText(formatted)
+      setCopyStatus('Copied')
+    } catch {
+      setCopyStatus('Copy failed')
+    }
+  }
+
+  function downloadJson() {
+    const blob = new Blob([formatted], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `${selected || 'recognition-output'}.json`
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+        <select
+          aria-label="Recognition session"
+          value={selected}
+          onChange={event => loadSession(event.target.value)}
+          style={{ flex: '1 1 420px' }}
+        >
+          <option value="">Select a recognition session...</option>
+          {sessions.map(session => (
+            <option key={session.sessionId} value={session.sessionId}>
+              {session.sessionId} — {session.recognitionFileCount} JSON file{session.recognitionFileCount === 1 ? '' : 's'}
+            </option>
+          ))}
+        </select>
+        <button onClick={refresh} disabled={loading}>↻ Refresh</button>
+        <button onClick={copyJson} disabled={!formatted}>Copy JSON</button>
+        <button className="primary" onClick={downloadJson} disabled={!formatted}>Download JSON</button>
+        {copyStatus && <span style={{ fontSize: 12, color: 'var(--text-dim)' }}>{copyStatus}</span>}
+      </div>
+
+      <div className="card" style={{ padding: 0, overflow: 'hidden' }}>
+        <div style={{ padding: '10px 12px', borderBottom: '1px solid var(--border)', fontSize: 13, fontWeight: 600 }}>
+          Recognition JSON
+        </div>
+        {loading ? (
+          <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-dim)' }}>Loading recognition output…</div>
+        ) : error ? (
+          <div style={{ padding: 20, color: 'var(--red)' }}>{error}</div>
+        ) : formatted ? (
+          <div style={{ minHeight: 500, maxHeight: '72vh', overflow: 'auto' }}>
+            <JsonHighlighter text={formatted} />
+          </div>
+        ) : (
+          <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-dim)' }}>No recognition JSON is available.</div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What changed

- Persist the correlation result as a stable JSON recognition artifact in S3.
- Add a Recognition JSON tab to the current UI.
- List recognition sessions and load multi-page JSON results through server-side APIs.
- Provide copy and download actions without exposing S3 access to the browser.
- Recover a usable JSON artifact when a model response contains surrounding text or malformed XML.

## Why this change is proposed

The processing pipeline produces specialist and correlated artifacts, but the UI does not provide a direct machine-readable result view. Users can see chat progress yet have no clear place to inspect, copy, or download the final recognition output. Strict parsing can also leave no consumable artifact when otherwise useful model output has minor formatting defects.

This change gives every correlated page a predictable JSON representation and makes those files accessible through the existing authenticated server boundary.

## Benefits

- Enables downstream automation without scraping chat text.
- Makes processing results visible and testable in the current UI.
- Supports multi-page sessions while retaining per-page provenance.
- Keeps bucket names, object access, and AWS credentials out of the browser.
- Produces an explicit parse status when recovery was required.

## Validation

- Processed a deployed image workflow and verified a correlation JSON artifact was written.
- Verified the Recognition JSON tab can list, load, copy, and download results.
- Verified recovery output remains valid JSON.
- Verified production UI build with pnpm and Python module compilation.
- Reviewed the branch against the current upstream `main`.

Authored by Saeed Kasmani (`amirgholipour`).
