### PR TITLE
Fix assistant UI state selectors

### DIFF
--- a/ui/src/components/Chat.jsx
+++ b/ui/src/components/Chat.jsx
@@ -101,10 +101,13 @@ function UserMessage() {
 }
 
 function AssistantMessage() {
-  const message = useAuiState()
-  const isRunning = message.status?.type === 'running'
-  const hasText = message.content?.some(c => c.type === 'text' && c.text?.trim())
-  const reasoningParts = message.content?.filter(c => c.type === 'reasoning') || []
+  // Current assistant-ui versions require an explicit state selector.
+  // Subscribe only to the fields this message renderer uses so streaming
+  // updates remain stable and do not try to read the entire store.
+  const isRunning = useAuiState(s => s.message.status?.type === 'running')
+  const content = useAuiState(s => s.message.content)
+  const hasText = content?.some(c => c.type === 'text' && c.text?.trim())
+  const reasoningParts = content?.filter(c => c.type === 'reasoning') || []
 
   if (!hasText && isRunning) {
     return (


### PR DESCRIPTION
## What changed

- Update the assistant message renderer to use explicit `useAuiState` selectors.
- Subscribe only to the message status and content fields used by the component.

## Why this change is proposed

The current UI dependency expects a selector when reading assistant state. Calling the hook without one can fail during rendering or streaming after the dependency update already present on upstream `main`.

The fix follows the current state API and narrows subscriptions to the fields that actually drive the message view.

## Benefits

- Restores stable assistant-message rendering with the current dependency version.
- Preserves streaming status, text, and reasoning display.
- Avoids unnecessary rerenders caused by subscribing to the entire store.
- Changes only the affected current-UI component.

## Validation

- Verified the current production UI build completes with pnpm.
- Exercised streaming assistant output in the integrated UI.
- Reviewed the one-file diff against the current upstream `main`.

Authored by Saeed Kasmani (`amirgholipour`).
