### PR TITLE
Harden local UI startup

### DIFF
--- a/ui/server/index.js
+++ b/ui/server/index.js
@@ -173,6 +173,7 @@ mountAdminRoutes(app, PROJECT_ROOT);
 
 // ── Static serving ──
 const PORT = process.env.PORT || 7860;
+const HOST = process.env.HOST || '127.0.0.1';
 
 async function startServer() {
     await loadSSMConfig();
@@ -202,8 +203,8 @@ async function startServer() {
         app.use(vite.middlewares);
     }
 
-    app.listen(PORT, () => {
-        console.log(`\n🦡 BADGERS Unified UI on http://localhost:${PORT}\n`);
+    app.listen(PORT, HOST, () => {
+        console.log(`\n🦡 BADGERS Unified UI on http://${HOST}:${PORT}\n`);
     });
 }
 

--- a/ui/server/routes/core.js
+++ b/ui/server/routes/core.js
@@ -202,10 +202,12 @@ export function mountCoreRoutes(app, PROJECT_ROOT) {
 
         mkdirSync(LOGS_DIR, { recursive: true });
         const safeSessionId = session_id.replace(/[^a-zA-Z0-9_-]/g, '');
-        const logFile = resolve(LOGS_DIR, `${safeSessionId}.log`);
-        // Normalize the path and verify it's within the allowed logs directory
-        const normalizedLogFile = realpathSync(logFile);
+        // The log file does not exist on the first message in a session, so
+        // realpathSync would fail before the first append. Resolve the future
+        // path and keep the same containment check instead.
+        const normalizedLogFile = resolve(LOGS_DIR, `${safeSessionId}.log`);
         if (!normalizedLogFile.startsWith(LOGS_DIR + '/')) return res.status(403).json({ error: 'Forbidden' });
+        const logFile = normalizedLogFile;
         const log = (line) => { appendFile(logFile, line + '\n').catch(() => { }); };
         log(`\n${'='.repeat(60)}`);
         log(`[${new Date().toISOString()}] USER: ${message}`);


### PR DESCRIPTION
## What changed

- Bind the local Express server to `127.0.0.1` by default, with an explicit `HOST` override.
- Resolve a new chat-session log path without requiring the not-yet-created file to exist.
- Keep the existing log-directory containment check before appending.

## Why this change is proposed

Two startup-path details make first-run development unreliable. The server currently binds using the platform default, which may expose a local development service beyond loopback. Separately, the first chat message calls `realpathSync` on a log file before that file exists, so a brand-new session can fail before its first append.

The server now has a safe loopback default, and the future log path is resolved and checked before creation.

## Benefits

- Safer local defaults without changing deployed environments that set `HOST`.
- First messages work in newly created chat sessions.
- Existing traversal protection remains in place.
- The change is limited to server startup and logging behavior.

## Validation

- Verified both changed server modules with Node syntax checks.
- Verified the integrated current UI can create and process a new session.
- Verified the production UI build completes with pnpm.
- Reviewed the branch against the current upstream `main`.

Authored by Saeed Kasmani (`amirgholipour`).
