### PR TITLE
Improve image enhancer reliability

### DIFF
--- a/deployment/lambdas/containers/image_enhancer/DEPLOYMENT.md
+++ b/deployment/lambdas/containers/image_enhancer/DEPLOYMENT.md
@@ -78,7 +78,7 @@ Set in `lambda_stack.py` or override in AWS console:
 |----------|---------|---------|
 | `VISION_MODEL` | `us.anthropic.claude-sonnet-4-6` | Bedrock model ID |
 | `MAX_ITERATIONS` | `2` | Max agent iterations |
-| `MAX_IMAGE_DIMENSION` | `4000` | Max dimension for LLM |
+| `MAX_IMAGE_DIMENSION` | `2048` | Max dimension for LLM |
 | `JPEG_QUALITY` | `85` | LLM image encoding quality |
 | `OUTPUT_QUALITY` | `95` | Final output quality |
 | `OUTPUT_BUCKET` | (from CDK) | S3 bucket for enhanced images |
@@ -343,7 +343,7 @@ aws lambda update-function-configuration \
   --environment Variables="{
     VISION_MODEL=us.anthropic.claude-sonnet-4-6,
     MAX_ITERATIONS=3,
-    MAX_IMAGE_DIMENSION=4000
+    MAX_IMAGE_DIMENSION=2048
   }"
 ```
 

--- a/deployment/lambdas/containers/image_enhancer/Dockerfile
+++ b/deployment/lambdas/containers/image_enhancer/Dockerfile
@@ -28,6 +28,10 @@ COPY lambda_handler.py ${LAMBDA_TASK_ROOT}/
 # into the build context from ./layer/python/foundation before docker build.
 COPY foundation/ ${LAMBDA_TASK_ROOT}/foundation/
 
+# Foundation imports the shared config package during initialization. The build
+# scripts stage it alongside foundation, so include it in the runtime image too.
+COPY config/ ${LAMBDA_TASK_ROOT}/config/
+
 # Fix file permissions
 RUN chmod 644 ${LAMBDA_TASK_ROOT}/*.py
 

--- a/deployment/lambdas/containers/image_enhancer/README.md
+++ b/deployment/lambdas/containers/image_enhancer/README.md
@@ -154,7 +154,7 @@ Maps to MAX_ITERATIONS for the agent:
 |----------|---------|-------------|
 | `VISION_MODEL` | `us.anthropic.claude-sonnet-4-6` | Bedrock model ID |
 | `MAX_ITERATIONS` | `2` | Max agent iterations (overridden by enhancement_level at runtime) |
-| `MAX_IMAGE_DIMENSION` | `4000` | Max dimension for LLM submission |
+| `MAX_IMAGE_DIMENSION` | `2048` | Max dimension for LLM submission |
 | `JPEG_QUALITY` | `85` | Quality for LLM image encoding |
 | `OUTPUT_QUALITY` | `95` | Quality for final output |
 | `OUTPUT_BUCKET` | - | S3 bucket for enhanced images (if not set, returns base64) |

--- a/deployment/lambdas/containers/image_enhancer/agentic_enhancer.py
+++ b/deployment/lambdas/containers/image_enhancer/agentic_enhancer.py
@@ -39,7 +39,7 @@ VISION_MODEL = os.environ.get(
     "CLAUDE_OPUS_46_PROFILE_ARN", "us.anthropic.claude-opus-4-6-v1"
 )
 MAX_ITERATIONS = int(os.environ.get("MAX_ITERATIONS", "2"))
-MAX_IMAGE_DIMENSION = int(os.environ.get("MAX_IMAGE_DIMENSION", "4000"))
+MAX_IMAGE_DIMENSION = int(os.environ.get("MAX_IMAGE_DIMENSION", "2048"))
 JPEG_QUALITY = int(os.environ.get("JPEG_QUALITY", "85"))
 OUTPUT_QUALITY = int(os.environ.get("OUTPUT_QUALITY", "95"))
 

--- a/deployment/lambdas/containers/image_enhancer/lambda_handler.py
+++ b/deployment/lambdas/containers/image_enhancer/lambda_handler.py
@@ -278,7 +278,12 @@ def _upload_to_s3(local_path: str, bucket: str, session_id: str, original: str) 
     timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
     output_key = f"{session_id}/enhanced/{original_name}_enhanced_{timestamp}.jpg"
 
-    s3.upload_file(local_path, bucket, output_key)
+    s3.upload_file(
+        local_path,
+        bucket,
+        output_key,
+        ExtraArgs={"ContentType": "image/jpeg"},
+    )
     return f"s3://{bucket}/{output_key}"
 
 


### PR DESCRIPTION
## What changed

- Include the staged shared `config` package in the image-enhancer container.
- Reduce the default model-facing maximum image dimension from 4000 to 2048 pixels.
- Store enhanced JPEG objects with the correct `image/jpeg` content type.
- Update the enhancer deployment documentation to match the runtime default.

## Why this change is proposed

The container build stages shared configuration alongside the foundation package but did not copy that configuration into the image, which can cause imports to fail at startup. Large model-facing images also increase payload size and latency without improving extraction proportionally, and uploaded JPEG results lacked explicit content metadata.

These changes align container contents with the build process, keep model payloads within a practical size, and make enhanced artifacts self-describing in S3.

## Benefits

- Prevents a packaging-time dependency from becoming a runtime import failure.
- Reduces memory use, request size, and model latency for large scans.
- Allows browsers and downstream tools to handle enhanced JPEGs correctly.
- Keeps the final saved image quality setting independent of model-input resizing.

## Validation

- Built and deployed the enhancer container in an isolated BADGERS deployment.
- Processed a large PNG and verified a JPEG result was written successfully.
- Verified the output object reports `image/jpeg`.
- Verified the changed Python modules compile.
- Reviewed the branch against the current upstream `main`.

Authored by Saeed Kasmani (`amirgholipour`).
