### PR TITLE
Wait for the final WebSocket result

### DIFF
--- a/deployment/runtime/agent/main-websocket.py
+++ b/deployment/runtime/agent/main-websocket.py
@@ -599,7 +599,9 @@ Include session_id: "{runtime_session_id}" in ALL tool calls."""
                 yield {"start": True}
                 continue
             if event_data.get("complete"):
-                yield {"complete": True, "response": final_response}
+                # Strands emits this lifecycle marker before its AgentResult.
+                # The client treats completion as terminal, so wait for the
+                # result event below instead of closing the stream early.
                 continue
             if event_data.get("force_stop"):
                 yield {


### PR DESCRIPTION
## What changed

- Treat Strands' early `complete` lifecycle marker as non-terminal.
- Keep the WebSocket stream open until the later `AgentResult` event is emitted.

## Why this change is proposed

The runtime emits a lifecycle completion marker before it emits the final result object. The UI server treats a completion event as terminal and closes its WebSocket immediately. As a result, the final response and any result-level metrics can be lost even though processing completed successfully.

The runtime now waits for the event that actually carries the final result before allowing the client to close the stream.

## Benefits

- Prevents successful responses from appearing empty or incomplete.
- Preserves final response content and result-level metadata.
- Aligns the runtime event sequence with the current UI server's terminal-event behavior.
- Changes only the incorrect lifecycle ordering assumption.

## Validation

- Confirmed the early lifecycle marker precedes `AgentResult` in a deployed runtime.
- Verified a short deployed WebSocket request reaches the final result event.
- Verified the changed runtime module compiles.
- Reviewed the one-file diff against the current upstream `main`.

Authored by Saeed Kasmani (`amirgholipour`).
